### PR TITLE
Refactor: group controller changes

### DIFF
--- a/src/group/organizationGroup/organizationGroup.controller.ts
+++ b/src/group/organizationGroup/organizationGroup.controller.ts
@@ -15,7 +15,7 @@ export class OrganizationGroup {
     const cond = {};
     if (!(query && query.alsoDead && query.alsoDead === 'true')) cond['isAlive'] = 'true'; 
     const organizationGroups = await OrganizationGroup._organizationGroupRepository.find(cond);
-    return _.flatMap(<IOrganizationGroup[]>organizationGroups, k => <IOrganizationGroup>modifyOrganizationGroupBeforeSend(k,[]));
+    return _.flatMap(<IOrganizationGroup[]>organizationGroups, group => <IOrganizationGroup>modifyOrganizationGroupBeforeSend(group, []));
   }
 
   /**
@@ -161,7 +161,6 @@ export class OrganizationGroup {
    * @param childrenIDs id list of the groups to transfer
    */
   static async childrenAdoption(parentID: string, childrenIDs: string[]): Promise<void> {
-    // get parent
     // filter out non existing children
     const children = await OrganizationGroup._organizationGroupRepository.getSome(childrenIDs);
     const existingChildrenIds = children.map(group => group.id);

--- a/src/group/organizationGroup/organizationGroup.controller.ts
+++ b/src/group/organizationGroup/organizationGroup.controller.ts
@@ -1,10 +1,8 @@
 import { Request, Response, NextFunction } from 'express';
 import { OrganizationGroupRepository } from './organizationGroup.repository';
 import { IOrganizationGroup, ORGANIZATION_GROUP_OBJECT_FIELDS, ORGANIZATION_GROUP_KEYS } from './organizationGroup.interface';
-import { Person } from '../../person/person.controller';
 import { IPerson } from '../../person/person.interface';
 import { PersonRepository } from '../../person/person.repository';
-import { Document } from 'mongoose';
 import * as _ from 'lodash';
 import { sortObjectsByIDArray, promiseAllWithFails, asyncForEach } from '../../utils';
 import { ValidationError, ResourceNotFoundError } from '../../types/error';
@@ -13,24 +11,17 @@ export class OrganizationGroup {
   static _organizationGroupRepository: OrganizationGroupRepository = new OrganizationGroupRepository();
   static _personRepository: PersonRepository = new PersonRepository();
 
-// Used for a 'getAll' route that no longer exists
-/*   static async getAllOrganizationGroups(): Promise<IOrganizationGroup[]> {
-    const organizationGroups = await OrganizationGroup._organizationGroupRepository.getAll();
-    return <IOrganizationGroup[]>organizationGroups;
-  } */
-
   static async getOrganizationGroups(query?: any): Promise<IOrganizationGroup[]> {
     const cond = {};
     if (!(query && query.alsoDead && query.alsoDead === 'true')) cond['isAlive'] = 'true'; 
     const organizationGroups = await OrganizationGroup._organizationGroupRepository.find(cond);
-    const fieldsToSend = <(keyof IOrganizationGroup)[]>_.difference(ORGANIZATION_GROUP_KEYS, ['directMembers', 'directManagers']);
-    return _.flatMap(<IOrganizationGroup[]>organizationGroups, k => pick(k, ...fieldsToSend));
+    return _.flatMap(<IOrganizationGroup[]>organizationGroups, k => <IOrganizationGroup>modifyOrganizationGroupBeforeSend(k,[]));
   }
 
   /**
    * Checks if there is a group with this hierarchy
    * @param name Name of OrganizationGgroup
-   * @param hierarchy Hierarchy of OrganizationGgroup
+   * @param hierarchy Hierarchy of OrganizationGroup
    */
   static async getOrganizationGroupByHierarchy(name: string, hierarchy: string[]): Promise<IOrganizationGroup> {
     const cond = {
@@ -52,6 +43,7 @@ export class OrganizationGroup {
   static async getIDofOrganizationGroupsInHierarchy(hierarchy: string[]) {
     const groups: IOrganizationGroup[] = await promiseAllWithFails(hierarchy.map((p, index, hierarchy) => OrganizationGroup.getOrganizationGroupByHierarchy(p, hierarchy.slice(0, index))), null);
     const groupsID = {};
+
     for (let index = 0; index < hierarchy.length; index++) {
       const value = groups[index].id ? groups[index].id : null;
       const key = hierarchy.slice(0, index + 1).join('/');
@@ -79,7 +71,6 @@ export class OrganizationGroup {
   * @param parentID ID of parent of organizationGroup to insert 
   */
   static async createOrganizationGroup(organizationGroup: IOrganizationGroup, parentID: string = undefined): Promise<IOrganizationGroup> {
-
     const parent = parentID ? await OrganizationGroup._organizationGroupRepository.findById(parentID) : null;
     // the parent does not exist
     if (parentID && !parent) throw new ResourceNotFoundError(`group with id: ${parentID} does not exist`);
@@ -87,7 +78,6 @@ export class OrganizationGroup {
     /* In case there is a parent checking that all his ancestor 
        lives and creates a hierarchy and an ancestor */
     if (parentID) {
-
       // If the parent is not alive checks all the other ancestors
       if (!parent.isAlive) {
         const parentAncestors = await OrganizationGroup.getAncestors(parentID, { isAlive: false });
@@ -146,26 +136,9 @@ export class OrganizationGroup {
     return newOrganizationGroup;
   }
 
-  static async getOrganizationGroupOld(organizationGroupID: string): Promise<IOrganizationGroup> {
-    const organizationGroup = await OrganizationGroup._organizationGroupRepository.findById(organizationGroupID);
-    if (!organizationGroup) throw new ResourceNotFoundError('Cannot find group with ID: ' + organizationGroupID);
-    return <IOrganizationGroup>organizationGroup;
-  }
-
-  static async getOrganizationGroupPopulated(organizationGroupID: string): Promise<IOrganizationGroup> {
-    const organizationGroup = await OrganizationGroup._organizationGroupRepository.findById(organizationGroupID, 'children');
-    if (!organizationGroup) throw new ResourceNotFoundError('Cannot find group with ID: ' + organizationGroupID);
-    return <IOrganizationGroup>organizationGroup;
-  }
-
   static async getOrganizationGroup(organizationGroupID: string, toPopulate?: String[]): Promise<IOrganizationGroup> {
     toPopulate = _.intersection(toPopulate, ORGANIZATION_GROUP_OBJECT_FIELDS);
-    // fields to select in the populated objects (can be groups and persons)
-    const select = ['id', 'name', 'isALeaf', 'serviceType', 'rank', 'firstName', 'lastName', 'status'];
-    const populateOptions = _.flatMap(toPopulate, (path) => {
-      return { path, select };
-    });
-    const result = await OrganizationGroup._organizationGroupRepository.findById(organizationGroupID, populateOptions);
+    const result = await OrganizationGroup._organizationGroupRepository.findById(organizationGroupID, toPopulate);
     if (!result) throw new ResourceNotFoundError('Cannot find group with ID: ' + organizationGroupID);
     const organizationGroup = <IOrganizationGroup>result;
     return <IOrganizationGroup>modifyOrganizationGroupBeforeSend(organizationGroup, toPopulate);
@@ -182,10 +155,6 @@ export class OrganizationGroup {
     return updated;
   }
 
-  static async changeName(groupID: string, name: string): Promise<IOrganizationGroup> {
-    return;
-  }
-
   /**
    * change the parent of groups (transfer them to another group)
    * @param parentID the group to transfer into (the new parent)
@@ -193,17 +162,16 @@ export class OrganizationGroup {
    */
   static async childrenAdoption(parentID: string, childrenIDs: string[]): Promise<void> {
     // get parent
-    const parent = await OrganizationGroup.getOrganizationGroupOld(parentID);
     // filter out non existing children
     const children = await OrganizationGroup._organizationGroupRepository.getSome(childrenIDs);
     const existingChildrenIds = children.map(group => group.id);
     // Checks if the parentID is included in chldrenIDs. If it's true, 
     // it creates "Recursive Adoption" and it will stuck the program and spam the DB.  
     if (childrenIDs.includes(parentID)) {
-      throw new ValidationError('The parentId inclueds in childrenIDs, Cannot insert organizationGroup itself');
+      throw new ValidationError('The parentId includes in childrenIDs, Cannot insert organizationGroup itself');
     }
     // Update the children's previous parents
-    await asyncForEach(children, async (child: IOrganizationGroup, index: number, children: IOrganizationGroup[]) => {
+    await asyncForEach(children, async (child: IOrganizationGroup) => {
       await OrganizationGroup.disownChild(child.ancestors[0], child.id);
     });
     // Update the parent and the children
@@ -280,7 +248,7 @@ export class OrganizationGroup {
    * @param childrenIDs the children to update
    */
   private static async updateChildrenHierarchy(parentID: string, childrenIDs: string[] = []): Promise<void> {
-    const parent = await OrganizationGroup.getOrganizationGroupOld(parentID);
+    const parent = await OrganizationGroup.getOrganizationGroup(parentID);
     if (childrenIDs.length === 0) {
       // update the current children - neccessary for the recursion to work
       childrenIDs = <string[]>(parent.children);
@@ -289,7 +257,7 @@ export class OrganizationGroup {
     ancestors.unshift(parentID);
     const hierarchy = await OrganizationGroup.getHierarchyFromAncestors(parentID);
     hierarchy.unshift(parent.name);
-    const updated = await OrganizationGroup._organizationGroupRepository.findAndUpdateSome(childrenIDs, { ancestors, hierarchy });
+    await OrganizationGroup._organizationGroupRepository.findAndUpdateSome(childrenIDs, { ancestors, hierarchy });
     await promiseAllWithFails(childrenIDs.map((childID => OrganizationGroup.updateChildrenHierarchy(childID))));
     return;
   }
@@ -302,7 +270,7 @@ export class OrganizationGroup {
    */
   private static async adoptChildren(parentID: string, childrenIDs: string[], parent?: IOrganizationGroup): Promise<IOrganizationGroup> {
     if (!parent) {
-      parent = await OrganizationGroup.getOrganizationGroupOld(parentID);
+      parent = await OrganizationGroup.getOrganizationGroup(parentID);
     }
     // Add the new children if they dont exist yet
     const children = (<string[]>parent.children).concat(childrenIDs);
@@ -316,7 +284,7 @@ export class OrganizationGroup {
 
   private static async disownChild(parentID: string, childID: string): Promise<IOrganizationGroup> {
     if (!parentID) return;
-    const parent = await OrganizationGroup.getOrganizationGroupOld(parentID);
+    const parent = await OrganizationGroup.getOrganizationGroup(parentID);
     _.remove(<string[]>parent.children, (item) => { return item.toString() === childID; });
     if (parent.children.length === 0) {
       parent.isALeaf = true;
@@ -329,7 +297,7 @@ export class OrganizationGroup {
    * @param organizationGroupID ID of group we want its ancestors
    */
   private static async getIDAncestors(organizationGroupID: string): Promise<string[]> {
-    const organizationGroup = await OrganizationGroup.getOrganizationGroupOld(organizationGroupID);
+    const organizationGroup = await OrganizationGroup.getOrganizationGroup(organizationGroupID);
     if (!organizationGroup.ancestors) return [];
     return <string[]>organizationGroup.ancestors;
   }
@@ -340,7 +308,7 @@ export class OrganizationGroup {
    * @param cond Condition of query
    */
   private static async getAncestors(organizationGroupID: string, cond: Object = {}): Promise<IOrganizationGroup[]> {
-    const organizationGroup = await OrganizationGroup.getOrganizationGroupOld(organizationGroupID);
+    const organizationGroup = await OrganizationGroup.getOrganizationGroup(organizationGroupID);
     if (!organizationGroup.ancestors) return [];
 
     // If there are conditions adding them to the request, otherwise no
@@ -351,26 +319,15 @@ export class OrganizationGroup {
     return <IOrganizationGroup[]>sortObjectsByIDArray(ancestorObjects, organizationGroup.ancestors);
   }
 
-  /**
-   * Return true if person is a member of group 
-   * @param groupID 
-   * @param personID 
-   */
-  private static async isMember(groupID: string, personID: string): Promise<boolean> {
-    const members = await OrganizationGroup.getAllMembers(groupID);
-    const memberIDs = members.map(member => member.id);
-    return _.includes(<string[]>memberIDs, personID);
-  }
-
   private static async getHierarchyFromAncestors(parentID: string): Promise<string[]> {
-    const parent = await OrganizationGroup.getOrganizationGroupOld(parentID);
+    const parent = await OrganizationGroup.getOrganizationGroup(parentID);
     if (!parent.hierarchy) return [];
     return parent.hierarchy;
   }
 
   static async getAllMembers(groupID: string): Promise<IPerson[]> {
     // check that this group exists
-    const group = await OrganizationGroup.getOrganizationGroupOld(groupID);
+    await OrganizationGroup.getOrganizationGroup(groupID);
     const offsprings = await OrganizationGroup._organizationGroupRepository.getOffspringsIds(groupID);
     const offspringIDs = offsprings.map(offspring => offspring.id);
     offspringIDs.push(groupID);
@@ -389,7 +346,6 @@ export class OrganizationGroup {
     return OrganizationGroup._organizationGroupRepository.getOffsprings(id, maxDepth);
   }
 }
-
 
 function modifyOrganizationGroupBeforeSend(organizationGroup: IOrganizationGroup, toPopulate: String[]): IOrganizationGroup {
   if (organizationGroup.isALeaf === undefined) {

--- a/src/group/organizationGroup/organizationGroup.interface.ts
+++ b/src/group/organizationGroup/organizationGroup.interface.ts
@@ -14,4 +14,4 @@ export interface IOrganizationGroup extends IGroup {
 
 export const ORGANIZATION_GROUP_BASIC_FIELDS = ['name', 'clearance', 'type', 'isALeaf','akaUnit'];
 export const ORGANIZATION_GROUP_OBJECT_FIELDS = ['ancestors', 'children','directMembers', 'directManagers'];
-export const ORGANIZATION_GROUP_KEYS = ['id', 'updatedAt', 'name', 'clearance', 'type', 'hierarchy', 'ancestors', 'children', 'directMembers', 'directManagers', 'isALeaf','akaUnit'];
+export const ORGANIZATION_GROUP_KEYS = ['id', 'updatedAt', 'name', 'clearance', 'type', 'hierarchy', 'ancestors', 'children', 'directMembers', 'directManagers', 'isALeaf','isAlive','akaUnit'];

--- a/src/group/organizationGroup/organizationGroup.route.ts
+++ b/src/group/organizationGroup/organizationGroup.route.ts
@@ -59,15 +59,6 @@ organizationGroups.post('/',
     return [organizationGroup, parentId];
   }));
 
-// delete this route ?
-organizationGroups.get('/:id/old', (req: Request, res: Response) => {
-  const getFunction = (req.query.populated === 'true') ? OrganizationGroup.getOrganizationGroupPopulated : OrganizationGroup.getOrganizationGroupOld;
-  ch(getFunction, (req: Request, res: Response) => {
-    return [req.params.id];
-  })(req, res, null);
-
-});
-
 organizationGroups.get('/:id/members', 
           validatorMiddleware(Vld.validMongoId, ['id'], 'params'),
           ch(OrganizationGroup.getAllMembers, (req: Request, res: Response) => [req.params.id]));

--- a/src/group/organizationGroup/organizationGroup.spec.ts
+++ b/src/group/organizationGroup/organizationGroup.spec.ts
@@ -280,7 +280,7 @@ describe('Strong Groups', () => {
       const hideOrgGrp = await OrganizationGroup.hideGroup(orgGrp.id);
       const hideAncstr3 = await OrganizationGroup.hideGroup(ancstr3.id);
       const hideAncstr2 = await OrganizationGroup.hideGroup(ancstr2.id);
-      const hideAncstr1 = await OrganizationGroup.getOrganizationGroupOld(ancstr1.id);
+      const hideAncstr1 = await OrganizationGroup.getOrganizationGroup(ancstr1.id);
 
       expect(hideAncstr2.isAlive).to.be.false;
       expect(hideAncstr3.isAlive).to.be.false;
@@ -289,9 +289,9 @@ describe('Strong Groups', () => {
       expect(hideAncstr2.children).to.be.empty;
       expect(hideAncstr1.children).to.be.empty;
       const orgGrpRvive: IOrganizationGroup = await OrganizationGroup.createOrganizationGroup(<IOrganizationGroup>{ ...GROUP_ARRAY[3] }, ancstr3.id);
-      const liveancstr1: IOrganizationGroup = await OrganizationGroup.getOrganizationGroupOld(ancstr1.id);
-      const liveancstr2: IOrganizationGroup = await OrganizationGroup.getOrganizationGroupOld(ancstr2.id);
-      const liveancstr3: IOrganizationGroup = await OrganizationGroup.getOrganizationGroupOld(ancstr3.id);
+      const liveancstr1: IOrganizationGroup = await OrganizationGroup.getOrganizationGroup(ancstr1.id);
+      const liveancstr2: IOrganizationGroup = await OrganizationGroup.getOrganizationGroup(ancstr2.id);
+      const liveancstr3: IOrganizationGroup = await OrganizationGroup.getOrganizationGroup(ancstr3.id);
       expect(orgGrp.id).to.equal(orgGrpRvive.id);
       expect(orgGrpRvive.isAlive).to.be.true;
       expect(liveancstr3.isAlive).to.be.true;
@@ -343,22 +343,22 @@ describe('Strong Groups', () => {
       groupAfterdischarge.should.have.property('directMembers');
       groupAfterdischarge.directMembers.should.have.lengthOf(0);
     });
-    it('should return the group populated', async () => {
-      const organizationGroup = await OrganizationGroup.createOrganizationGroup(<IOrganizationGroup>{ name: 'myGroup' });
-      const child1 = await OrganizationGroup.createOrganizationGroup(<IOrganizationGroup>{ name: 'Child 1' }, organizationGroup.id);
-      const child2 = await OrganizationGroup.createOrganizationGroup(<IOrganizationGroup>{ name: 'Child 2' }, organizationGroup.id);
+    // it('should return the group populated', async () => {
+    //   const organizationGroup = await OrganizationGroup.createOrganizationGroup(<IOrganizationGroup>{ name: 'myGroup' });
+    //   const child1 = await OrganizationGroup.createOrganizationGroup(<IOrganizationGroup>{ name: 'Child 1' }, organizationGroup.id);
+    //   const child2 = await OrganizationGroup.createOrganizationGroup(<IOrganizationGroup>{ name: 'Child 2' }, organizationGroup.id);
 
-      const res = await OrganizationGroup.getOrganizationGroupPopulated(organizationGroup.id);
+    //   const res = await OrganizationGroup.getOrganizationGroupPopulated(organizationGroup.id);
 
-      res.should.exist;
-      res.should.have.property('id', organizationGroup.id);
-      res.should.have.property('name', organizationGroup.name);
-      const children = <IOrganizationGroup[]>res.children;
-      children.should.exist;
-      children.should.have.lengthOf(2);
-      children[0].name.should.be.equal(child1.name);
-      children[1].name.should.be.equal(child2.name);
-    });
+    //   res.should.exist;
+    //   res.should.have.property('id', organizationGroup.id);
+    //   res.should.have.property('name', organizationGroup.name);
+    //   const children = <IOrganizationGroup[]>res.children;
+    //   children.should.exist;
+    //   children.should.have.lengthOf(2);
+    //   children[0].name.should.be.equal(child1.name);
+    //   children[1].name.should.be.equal(child2.name);
+    // });
   });
   describe('Update OrganizationGroup', () => {
     describe('#updateOrganizationGroup', () => {
@@ -387,7 +387,7 @@ describe('Strong Groups', () => {
 
         await OrganizationGroup.childrenAdoption(parent.id, [child.id]);
 
-        child = await OrganizationGroup.getOrganizationGroupOld(child.id);
+        child = await OrganizationGroup.getOrganizationGroup(child.id);
 
         child.should.exist;
         child.should.have.property('ancestors');
@@ -404,7 +404,7 @@ describe('Strong Groups', () => {
 
         await OrganizationGroup.childrenAdoption(parent_old.id, [child.id]);
         await OrganizationGroup.childrenAdoption(parent.id, [child.id]);
-        child = await OrganizationGroup.getOrganizationGroupOld(child.id);
+        child = await OrganizationGroup.getOrganizationGroup(child.id);
 
         child.should.exist;
         child.should.have.property('ancestors');
@@ -419,7 +419,7 @@ describe('Strong Groups', () => {
         await OrganizationGroup.childrenAdoption(grandparent.id, [parent.id]);
         await OrganizationGroup.childrenAdoption(parent.id, [child.id]);
 
-        child = await OrganizationGroup.getOrganizationGroupOld(child.id);
+        child = await OrganizationGroup.getOrganizationGroup(child.id);
 
         child.should.exist;
         child.should.have.property('ancestors');
@@ -437,7 +437,7 @@ describe('Strong Groups', () => {
         await OrganizationGroup.childrenAdoption(parent.id, [child.id]);
         await OrganizationGroup.childrenAdoption(grandparent_2.id, [parent.id]);
 
-        child = await OrganizationGroup.getOrganizationGroupOld(child.id);
+        child = await OrganizationGroup.getOrganizationGroup(child.id);
 
         child.should.exist;
         child.should.have.property('ancestors');
@@ -450,7 +450,7 @@ describe('Strong Groups', () => {
         let child1 = await OrganizationGroup.createOrganizationGroup(<IOrganizationGroup>{ name: 'child1' }, oldParent.id);
         let child2 = await OrganizationGroup.createOrganizationGroup(<IOrganizationGroup>{ name: 'child2' }, oldParent.id);
         let child3 = await OrganizationGroup.createOrganizationGroup(<IOrganizationGroup>{ name: 'child3' }, oldParent.id);        
-        oldParent = await OrganizationGroup.getOrganizationGroupOld(oldParent.id);
+        oldParent = await OrganizationGroup.getOrganizationGroup(oldParent.id);
         oldParent.should.have.property('children');
         oldParent.children.should.have.lengthOf(3);
         expect(child1.ancestors[0].toString() === oldParent.id).to.be.ok;
@@ -458,11 +458,11 @@ describe('Strong Groups', () => {
         expect(child3.ancestors[0].toString() === oldParent.id).to.be.ok;
         let newParent = await OrganizationGroup.createOrganizationGroup(<IOrganizationGroup>{ name: 'new parent' });
         await OrganizationGroup.childrenAdoption(newParent.id, [child1.id, child2.id, child3.id]);
-        oldParent = await OrganizationGroup.getOrganizationGroupOld(oldParent.id);
-        newParent = await OrganizationGroup.getOrganizationGroupOld(newParent.id);
-        child1 = await OrganizationGroup.getOrganizationGroupOld(child1.id);
-        child2 = await OrganizationGroup.getOrganizationGroupOld(child2.id);
-        child3 = await OrganizationGroup.getOrganizationGroupOld(child3.id);
+        oldParent = await OrganizationGroup.getOrganizationGroup(oldParent.id);
+        newParent = await OrganizationGroup.getOrganizationGroup(newParent.id);
+        child1 = await OrganizationGroup.getOrganizationGroup(child1.id);
+        child2 = await OrganizationGroup.getOrganizationGroup(child2.id);
+        child3 = await OrganizationGroup.getOrganizationGroup(child3.id);
 
         oldParent.should.exist;
         oldParent.should.have.property('children');
@@ -483,7 +483,7 @@ describe('Strong Groups', () => {
         try {
           await OrganizationGroup.childrenAdoption(og.id, [og.id]);
         } catch (error) {
-          expect(error.message).to.equal(`The parentId inclueds in childrenIDs, Cannot insert organizationGroup itself`);
+          expect(error.message).to.equal(`The parentId includes in childrenIDs, Cannot insert organizationGroup itself`);
           isError = true;
         }
         isError.should.be.true;

--- a/src/group/organizationGroup/organizationGroup.spec.ts
+++ b/src/group/organizationGroup/organizationGroup.spec.ts
@@ -343,22 +343,22 @@ describe('Strong Groups', () => {
       groupAfterdischarge.should.have.property('directMembers');
       groupAfterdischarge.directMembers.should.have.lengthOf(0);
     });
-    // it('should return the group populated', async () => {
-    //   const organizationGroup = await OrganizationGroup.createOrganizationGroup(<IOrganizationGroup>{ name: 'myGroup' });
-    //   const child1 = await OrganizationGroup.createOrganizationGroup(<IOrganizationGroup>{ name: 'Child 1' }, organizationGroup.id);
-    //   const child2 = await OrganizationGroup.createOrganizationGroup(<IOrganizationGroup>{ name: 'Child 2' }, organizationGroup.id);
+    it('should return the group populated with children', async () => {
+      const organizationGroup = await OrganizationGroup.createOrganizationGroup(<IOrganizationGroup>{ name: 'myGroup' });
+      const child1 = await OrganizationGroup.createOrganizationGroup(<IOrganizationGroup>{ name: 'Child 1' }, organizationGroup.id);
+      const child2 = await OrganizationGroup.createOrganizationGroup(<IOrganizationGroup>{ name: 'Child 2' }, organizationGroup.id);
 
-    //   const res = await OrganizationGroup.getOrganizationGroupPopulated(organizationGroup.id);
+      const res = await OrganizationGroup.getOrganizationGroup(organizationGroup.id, ['children']);
 
-    //   res.should.exist;
-    //   res.should.have.property('id', organizationGroup.id);
-    //   res.should.have.property('name', organizationGroup.name);
-    //   const children = <IOrganizationGroup[]>res.children;
-    //   children.should.exist;
-    //   children.should.have.lengthOf(2);
-    //   children[0].name.should.be.equal(child1.name);
-    //   children[1].name.should.be.equal(child2.name);
-    // });
+      res.should.exist;
+      res.should.have.property('id', organizationGroup.id);
+      res.should.have.property('name', organizationGroup.name);
+      const children = <IOrganizationGroup[]>res.children;
+      children.should.exist;
+      children.should.have.lengthOf(2);
+      children[0].name.should.be.equal(child1.name);
+      children[1].name.should.be.equal(child2.name);
+    });
   });
   describe('Update OrganizationGroup', () => {
     describe('#updateOrganizationGroup', () => {

--- a/src/person/person.spec.ts
+++ b/src/person/person.spec.ts
@@ -1007,7 +1007,7 @@ describe('Persons', () => {
 });
 
 async function printTreeHeavy(sourceID: string, deep = 0) {
-  const source = await OrganizationGroup.getOrganizationGroupOld(sourceID);
+  const source = await OrganizationGroup.getOrganizationGroup(sourceID);
   let pre = '';
   for (let i = 0; i < deep; i++) {
     pre += '  ';


### PR DESCRIPTION
IsAlive field will always show on group now, is there a reason it wasnt  showing before?
one of the tests(revive test) expected isAlive field to exist on group, but using getOrganizationGroupOld, that didnt filter values.
getOrganizationGroup does filter values, and isAlive was getting filtered out.
I think there is no reason for that and isAlive should be shown.