### PR TITLE
bugfix/can-remove-domainUser-inactive-tamar

### DIFF
--- a/src/person/person.controller.ts
+++ b/src/person/person.controller.ts
@@ -146,9 +146,9 @@ export class Person {
     if (person.id !== personId) {
       throw new ValidationError(`The domain user: ${uniqueId} doesn't belong to person with id: ${personId}`);
     }
-    // if trying to remove the last domain user from a specific entity type - it's an error
-    if (person.entityType === consts.ENTITY_TYPE[2] && person.domainUsers.length === 1) {
-      throw new ValidationError(`entityType: ${consts.ENTITY_TYPE[2]} requires at leat 1 domainuser`);
+    // if trying to remove the last domain user from a specific entity type person while he is active - it's an error
+    if (person.entityType === consts.ENTITY_TYPE[2] && person.domainUsers.length === 1 && person.status === consts.STATUS.ACTIVE) {
+      throw new ValidationError(`entityType: ${consts.ENTITY_TYPE[2]} requires at leat 1 domainuser while is active`);
     }
     const { name, domain } = userFromString(uniqueId);
     const domains = getAllPossibleDomains(domain);

--- a/src/person/person.spec.ts
+++ b/src/person/person.spec.ts
@@ -13,7 +13,7 @@ import { domainMap, allStatuses } from '../utils';
 import * as mongoose from 'mongoose';
 import { RESPONSIBILITY, RANK, ENTITY_TYPE, DOMAIN_MAP, SERVICE_TYPE, CURRENT_UNIT, DATA_SOURCE, STATUS } from '../config/db-enums';
 import { config } from '../config/config';
-import { constantScoreQuery } from 'elastic-builder';
+
 const Types = mongoose.Types;
 const RESPONSIBILITY_DEFAULT = RESPONSIBILITY[0];
 

--- a/src/person/person.spec.ts
+++ b/src/person/person.spec.ts
@@ -13,6 +13,7 @@ import { domainMap, allStatuses } from '../utils';
 import * as mongoose from 'mongoose';
 import { RESPONSIBILITY, RANK, ENTITY_TYPE, DOMAIN_MAP, SERVICE_TYPE, CURRENT_UNIT, DATA_SOURCE, STATUS } from '../config/db-enums';
 import { config } from '../config/config';
+import { constantScoreQuery } from 'elastic-builder';
 const Types = mongoose.Types;
 const RESPONSIBILITY_DEFAULT = RESPONSIBILITY[0];
 
@@ -112,6 +113,14 @@ const personExamples: IPerson[] = [
     identityCard: '312571458',
     personalNumber: '2345676',
     firstName: 'blue',
+    entityType: ENTITY_TYPE[2],
+    domainUsers: [newUserExample],
+  },
+  <IPerson>{ // [6] inactive person that requires a domain user
+    identityCard: '312571458',
+    personalNumber: '2345676',
+    firstName: 'dead',
+    status: STATUS.INACTIVE,
     entityType: ENTITY_TYPE[2],
     domainUsers: [newUserExample],
   },
@@ -955,6 +964,12 @@ describe('Persons', () => {
         isError = true;
       }
       isError.should.be.true;
+    });
+    it('should allow domainUsers to be empty on person from type tamar if the person inactive', async () => {
+      const person = await Person.createPerson({ ...personExamples[6] });
+      const deletedPerson = await Person.deleteDomainUser(person.id, userStringEx);
+      deletedPerson.domainUsers.should.exist;
+      deletedPerson.domainUsers.should.have.lengthOf(0);
     });   
   });
   describe('#getByDomainUserString', () => {


### PR DESCRIPTION
If you want to take existing normal person and update him with tamar person values(including domain user), you need to first delete domainUser from tamar person, which you cant..
But we dont need that tamar person anymore, as his values gona go to normal person.
So we make that tamar person inactive, and then able to delete his domainUser, and as a result able to update normal person with this domainUser.